### PR TITLE
Add mark and unmark task commands

### DIFF
--- a/data/modules.txt
+++ b/data/modules.txt
@@ -1,0 +1,1 @@
+CS2113 | T | 0 | add mark

--- a/src/main/java/seedu/duke/command/MarkCommand.java
+++ b/src/main/java/seedu/duke/command/MarkCommand.java
@@ -1,0 +1,23 @@
+package seedu.duke.command;
+
+import seedu.duke.exception.ModuleSyncException;
+import seedu.duke.module.ModuleBook;
+import seedu.duke.storage.Storage;
+import seedu.duke.task.Task;
+import seedu.duke.ui.Ui;
+
+public class MarkCommand extends Command {
+    private final int taskNumber;
+
+    public MarkCommand(int taskNumber) {
+        this.taskNumber = taskNumber;
+    }
+
+    @Override
+    public void execute(ModuleBook moduleBook, Storage storage, Ui ui) throws ModuleSyncException {
+        Task task = moduleBook.getTaskByDisplayIndex(taskNumber);
+        task.markDone();
+        storage.save(moduleBook);
+        ui.showTaskMarked(task, taskNumber);
+    }
+}

--- a/src/main/java/seedu/duke/command/UnmarkCommand.java
+++ b/src/main/java/seedu/duke/command/UnmarkCommand.java
@@ -1,0 +1,23 @@
+package seedu.duke.command;
+
+import seedu.duke.exception.ModuleSyncException;
+import seedu.duke.module.ModuleBook;
+import seedu.duke.storage.Storage;
+import seedu.duke.task.Task;
+import seedu.duke.ui.Ui;
+
+public class UnmarkCommand extends Command {
+    private final int taskNumber;
+
+    public UnmarkCommand(int taskNumber) {
+        this.taskNumber = taskNumber;
+    }
+
+    @Override
+    public void execute(ModuleBook moduleBook, Storage storage, Ui ui) throws ModuleSyncException {
+        Task task = moduleBook.getTaskByDisplayIndex(taskNumber);
+        task.markUndone();
+        storage.save(moduleBook);
+        ui.showTaskUnmarked(task, taskNumber);
+    }
+}

--- a/src/main/java/seedu/duke/module/ModuleBook.java
+++ b/src/main/java/seedu/duke/module/ModuleBook.java
@@ -4,6 +4,9 @@ import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+import seedu.duke.exception.ModuleSyncException;
+import seedu.duke.task.Task;
+
 public class ModuleBook {
     private final Map<String, Module> modules = new LinkedHashMap<>();
 
@@ -19,5 +22,23 @@ public class ModuleBook {
         return modules.values().stream()
                 .mapToInt(module -> module.getTasks().size())
                 .sum();
+    }
+
+    public Task getTaskByDisplayIndex(int displayIndex) throws ModuleSyncException {
+        if (displayIndex <= 0) {
+            throw new ModuleSyncException("Task number must be a positive integer.");
+        }
+
+        int currentIndex = 1;
+        for (Module module : modules.values()) {
+            for (Task task : module.getTasks().asUnmodifiableList()) {
+                if (currentIndex == displayIndex) {
+                    return task;
+                }
+                currentIndex++;
+            }
+        }
+
+        throw new ModuleSyncException("Task number does not exist: " + displayIndex);
     }
 }

--- a/src/main/java/seedu/duke/parser/Parser.java
+++ b/src/main/java/seedu/duke/parser/Parser.java
@@ -1,9 +1,11 @@
 package seedu.duke.parser;
 
 import seedu.duke.command.AddTodoCommand;
-import seedu.duke.command.ListCommand;
 import seedu.duke.command.Command;
 import seedu.duke.command.ExitCommand;
+import seedu.duke.command.ListCommand;
+import seedu.duke.command.MarkCommand;
+import seedu.duke.command.UnmarkCommand;
 import seedu.duke.exception.ModuleSyncException;
 
 public class Parser {
@@ -20,6 +22,12 @@ public class Parser {
         }
         if (trimmed.equalsIgnoreCase("list")) {
             return new ListCommand();
+        }
+        if (trimmed.toLowerCase().startsWith("mark")) {
+            return parseMark(trimmed);
+        }
+        if (trimmed.toLowerCase().startsWith("unmark")) {
+            return parseUnmark(trimmed);
         }
         throw new ModuleSyncException("Unknown command. Try: add /mod MOD /task TASK");
     }
@@ -50,5 +58,28 @@ public class Parser {
             throw new ModuleSyncException("Usage: add /mod MOD /task DESCRIPTION");
         }
         return new AddTodoCommand(module, task);
+    }
+
+    private Command parseMark(String input) throws ModuleSyncException {
+        String remainder = input.length() > 4 ? input.substring(4).trim() : "";
+        int taskNumber = parseTaskNumber(remainder, "mark");
+        return new MarkCommand(taskNumber);
+    }
+
+    private Command parseUnmark(String input) throws ModuleSyncException {
+        String remainder = input.length() > 6 ? input.substring(6).trim() : "";
+        int taskNumber = parseTaskNumber(remainder, "unmark");
+        return new UnmarkCommand(taskNumber);
+    }
+
+    private int parseTaskNumber(String rawTaskNumber, String commandWord) throws ModuleSyncException {
+        if (rawTaskNumber.isEmpty()) {
+            throw new ModuleSyncException("Usage: " + commandWord + " TASK_NUMBER");
+        }
+        try {
+            return Integer.parseInt(rawTaskNumber);
+        } catch (NumberFormatException e) {
+            throw new ModuleSyncException("Task number must be a positive integer.");
+        }
     }
 }

--- a/src/main/java/seedu/duke/ui/Ui.java
+++ b/src/main/java/seedu/duke/ui/Ui.java
@@ -54,4 +54,14 @@ public class Ui {
             }
         }
     }
+
+    public void showTaskMarked(Task task, int taskNumber) {
+        System.out.println("Nice! I've marked this task as done:");
+        System.out.println("  " + task.formatForList(taskNumber));
+    }
+
+    public void showTaskUnmarked(Task task, int taskNumber) {
+        System.out.println("OK, I've marked this task as not done yet:");
+        System.out.println("  " + task.formatForList(taskNumber));
+    }
 }

--- a/src/test/java/seedu/duke/command/MarkCommandTest.java
+++ b/src/test/java/seedu/duke/command/MarkCommandTest.java
@@ -1,0 +1,55 @@
+package seedu.duke.command;
+
+import java.io.ByteArrayInputStream;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import seedu.duke.exception.ModuleSyncException;
+import seedu.duke.module.ModuleBook;
+import seedu.duke.storage.Storage;
+import seedu.duke.ui.Ui;
+
+class MarkCommandTest {
+
+    static class TestStorage extends Storage {
+        boolean saved;
+
+        TestStorage(Path path) {
+            super(path);
+        }
+
+        @Override
+        public void save(ModuleBook moduleBook) {
+            saved = true;
+        }
+    }
+
+    static class TestUi extends Ui {
+        TestUi() {
+            super(new java.util.Scanner(new ByteArrayInputStream(new byte[0])));
+        }
+
+        @Override
+        public void showTaskMarked(seedu.duke.task.Task task, int taskNumber) {
+            // no-op to keep test output clean
+        }
+    }
+
+    @Test
+    void execute_marksTaskAndSaves(@TempDir Path tempDir) throws ModuleSyncException {
+        ModuleBook moduleBook = new ModuleBook();
+        moduleBook.getOrCreate("CS2113").addTodo("Week8");
+        TestStorage storage = new TestStorage(tempDir.resolve("modules.txt"));
+        TestUi ui = new TestUi();
+
+        MarkCommand command = new MarkCommand(1);
+        command.execute(moduleBook, storage, ui);
+
+        var task = moduleBook.getOrCreate("CS2113").getTasks().asUnmodifiableList().get(0);
+        assertTrue(task.isDone());
+        assertTrue(storage.saved);
+    }
+}

--- a/src/test/java/seedu/duke/command/UnmarkCommandTest.java
+++ b/src/test/java/seedu/duke/command/UnmarkCommandTest.java
@@ -1,0 +1,56 @@
+package seedu.duke.command;
+
+import java.io.ByteArrayInputStream;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import seedu.duke.exception.ModuleSyncException;
+import seedu.duke.module.ModuleBook;
+import seedu.duke.storage.Storage;
+import seedu.duke.ui.Ui;
+
+class UnmarkCommandTest {
+
+    static class TestStorage extends Storage {
+        boolean saved;
+
+        TestStorage(Path path) {
+            super(path);
+        }
+
+        @Override
+        public void save(ModuleBook moduleBook) {
+            saved = true;
+        }
+    }
+
+    static class TestUi extends Ui {
+        TestUi() {
+            super(new java.util.Scanner(new ByteArrayInputStream(new byte[0])));
+        }
+
+        @Override
+        public void showTaskUnmarked(seedu.duke.task.Task task, int taskNumber) {
+            // no-op to keep test output clean
+        }
+    }
+
+    @Test
+    void execute_unmarksTaskAndSaves(@TempDir Path tempDir) throws ModuleSyncException {
+        ModuleBook moduleBook = new ModuleBook();
+        moduleBook.getOrCreate("CS2113").addTodo("Week8").markDone();
+        TestStorage storage = new TestStorage(tempDir.resolve("modules.txt"));
+        TestUi ui = new TestUi();
+
+        UnmarkCommand command = new UnmarkCommand(1);
+        command.execute(moduleBook, storage, ui);
+
+        var task = moduleBook.getOrCreate("CS2113").getTasks().asUnmodifiableList().get(0);
+        assertFalse(task.isDone());
+        assertTrue(storage.saved);
+    }
+}

--- a/src/test/java/seedu/duke/parser/ParserTest.java
+++ b/src/test/java/seedu/duke/parser/ParserTest.java
@@ -2,10 +2,11 @@ package seedu.duke.parser;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import org.junit.jupiter.api.Test;
 
 import seedu.duke.command.AddTodoCommand;
+import seedu.duke.command.MarkCommand;
+import seedu.duke.command.UnmarkCommand;
 import seedu.duke.exception.ModuleSyncException;
 
 class ParserTest {
@@ -23,5 +24,20 @@ class ParserTest {
         assertThrows(ModuleSyncException.class, () -> parser.parse("add /mod CS2113"));
         assertThrows(ModuleSyncException.class, () -> parser.parse("add /task OnlyTask"));
         assertThrows(ModuleSyncException.class, () -> parser.parse("add"));
+    }
+
+    @Test
+    void parse_markAndUnmark_returnsCorrectCommands() throws ModuleSyncException {
+        Parser parser = new Parser();
+        assertTrue(parser.parse("mark 1") instanceof MarkCommand);
+        assertTrue(parser.parse("unmark 2") instanceof UnmarkCommand);
+    }
+
+    @Test
+    void parse_markAndUnmarkInvalidInput_throws() {
+        Parser parser = new Parser();
+        assertThrows(ModuleSyncException.class, () -> parser.parse("mark"));
+        assertThrows(ModuleSyncException.class, () -> parser.parse("unmark"));
+        assertThrows(ModuleSyncException.class, () -> parser.parse("mark abc"));
     }
 }


### PR DESCRIPTION
Task status can only be changed indirectly, which makes simple progress updates inconvenient during normal use.

Users need a direct way to mark a task as done or not done while keeping the same task numbering shown in list output.

Add parser support for mark and unmark commands, execute task state updates through dedicated command classes, and save changes immediately.

Keep user feedback explicit after each status update and add tests for both parsing and command execution so valid and invalid inputs are covered.

Close #7 