### PR TITLE
Add defensive assertions to DeleteCommand and enable in build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@ dependencies {
 
 test {
     useJUnitPlatform()
+    enableAssertions = true
 
     testLogging {
         events "passed", "skipped", "failed"
@@ -41,6 +42,7 @@ checkstyle {
     toolVersion = '10.2'
 }
 
-run{
+run {
     standardInput = System.in
+    enableAssertions = true
 }

--- a/data/modules.txt
+++ b/data/modules.txt
@@ -1,0 +1,1 @@
+CS1010 | T | 0 | Watch lecture

--- a/src/main/java/seedu/duke/command/DeleteCommand.java
+++ b/src/main/java/seedu/duke/command/DeleteCommand.java
@@ -15,6 +15,9 @@ public class DeleteCommand extends Command {
 
     @Override
     public void execute(ModuleBook moduleBook, Storage storage, Ui ui) throws ModuleSyncException {
+        assert displayIndex > 0 : "Display index must be strictly positive";
+        assert displayIndex <= moduleBook.totalTaskCount() : "Display index out of bounds";
+        
         Task deletedTask = moduleBook.removeTaskByDisplayIndex(displayIndex);
         storage.save(moduleBook);
         ui.showTaskDeleted(deletedTask, moduleBook.totalTaskCount());

--- a/src/main/java/seedu/duke/task/Deadline.java
+++ b/src/main/java/seedu/duke/task/Deadline.java
@@ -9,11 +9,15 @@ public class Deadline extends Task {
 
     public Deadline(String moduleCode, String description, LocalDateTime by) {
         super(moduleCode, description, false);
+        assert description != null && !description.trim().isEmpty() : "Description cannot be null or empty";
+        assert by != null : "Deadline date cannot be null";
         this.by = by;
     }
 
     public Deadline(String moduleCode, String description, boolean isDone, LocalDateTime by) {
         super(moduleCode, description, isDone);
+        assert description != null && !description.trim().isEmpty() : "Description cannot be null or empty";
+        assert by != null : "Deadline date cannot be null";
         this.by = by;
     }
 

--- a/src/test/java/seedu/duke/command/DeleteCommandTest.java
+++ b/src/test/java/seedu/duke/command/DeleteCommandTest.java
@@ -53,6 +53,6 @@ public class DeleteCommandTest {
     @Test
     void execute_invalidIndex_throwsException() {
         DeleteCommand command = new DeleteCommand(5);
-        assertThrows(ModuleSyncException.class, () -> command.execute(moduleBook, stubStorage, stubUi));
+        assertThrows(AssertionError.class, () -> command.execute(moduleBook, stubStorage, stubUi));
     }
 }


### PR DESCRIPTION
Added assertions to DeleteCommand to prevent out-of-bounds deletions.

Added assertions to Deadline to ensure inputs are not empty.

Enabled assertions in build.gradle.