### PR TITLE
Implement list /deadlines command and enhance UI for deadlines

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -96,6 +96,77 @@ validation straightforward.
     * Cons: The `Command` layer would then need to handle user-facing error messages, blurring the
       separation of concerns between parsing and execution.
 
+//@@author Yap-Jia-Wei
+### [Feature] List Upcoming Deadlines (`list /deadlines`)
+
+#### Implementation
+
+The List Deadlines feature provides a specialized view that displays only tasks with deadlines,
+sorted chronologically from earliest to latest. This helps users plan their week by seeing
+upcoming deadlines at a glance. The feature filters out to-do tasks without deadlines and
+presents the filtered list in priority order.
+
+The feature implements the following operations:
+
+* `Parser#parseList(String)` — Parses the `list` command and checks for optional filters. When
+  `/deadlines` is detected, it returns a `ListDeadlinesCommand` instead of the regular `ListCommand`.
+* `ListDeadlinesCommand#execute(ModuleBook, Storage, Ui)` — Executes the deadline listing by
+  calling `Ui#showDeadlineList()`.
+* `Ui#showDeadlineList(ModuleBook)` — Collects all `Deadline` objects from all modules, sorts them
+  by due date in ascending order (earliest first), and displays them in a user-friendly format.
+
+Given below is the workflow for the List Deadlines feature:
+
+**Step 1.** The user inputs `list /deadlines`.
+
+**Step 2.** `ModuleSync#run()` calls `Ui#readCommand()`, which reads the raw input string from stdin.
+
+**Step 3.** `ModuleSync#run()` passes the raw string to `Parser#parse(...)`. The parser detects the
+`list` keyword and delegates to `Parser#parseList()`.
+
+**Step 4.** `Parser#parseList()` checks if the input contains `/deadlines`. If found, it instantiates
+a `ListDeadlinesCommand` and returns it; otherwise, it returns the regular `ListCommand`.
+
+**Step 5.** `ModuleSync#run()` calls `ListDeadlinesCommand#execute(moduleBook, storage, ui)`.
+
+**Step 6.** `execute()` delegates to `Ui#showDeadlineList(moduleBook)`.
+
+**Step 7.** `showDeadlineList()` iterates through all modules in the `ModuleBook` and collects all
+`Deadline` objects. For each deadline, it records the task number and module code.
+
+**Step 8.** The collected deadlines are sorted by their `LocalDateTime by` field in ascending order
+(earliest deadline first).
+
+**Step 9.** Finally, the sorted deadlines are displayed to the user, showing module code, status,
+description, due date/time, and days remaining.
+
+#### Design Considerations
+
+**Aspect: Filtering vs. separate command**
+
+* **Alternative 1 (Current choice): Use optional filter syntax `list /deadlines`.**
+    * Pros: Consistent with existing command structure. Can extend with more filters in future
+      (e.g., `list /todos`). Reduces command namespace pollution.
+    * Cons: Slightly more parsing logic in `Parser#parseList()`.
+
+* **Alternative 2: Create a separate command `deadlines` or `view-deadlines`.**
+    * Pros: Simpler parsing; no need to check for filters.
+    * Cons: Increases command count; less extensible for future filters.
+
+We chose the filter approach for consistency and extensibility.
+
+**Aspect: Sorting order for deadlines**
+
+* **Alternative 1 (Current choice): Sort by due date in ascending order (earliest first).**
+    * Pros: Users see the most urgent deadlines first, aiding prioritization.
+    * Cons: Does not highlight deadlines by urgency category (e.g., overdue vs. due soon vs. due later).
+
+* **Alternative 2: Sort by days remaining with urgency grouping (overdue, due this week, etc.).**
+    * Pros: Provides visual urgency categorization.
+    * Cons: Adds complexity to sorting logic and UI formatting.
+
+We chose ascending date order for simplicity and intuitive urgency ranking.
+
 
 ## Product scope
 ### Target user profile

--- a/src/main/java/seedu/modulesync/command/ListDeadlinesCommand.java
+++ b/src/main/java/seedu/modulesync/command/ListDeadlinesCommand.java
@@ -10,6 +10,9 @@ import seedu.modulesync.ui.Ui;
 public class ListDeadlinesCommand extends Command {
     @Override
     public void execute(ModuleBook moduleBook, Storage storage, Ui ui) {
+        assert moduleBook != null : "ModuleBook must not be null when executing ListDeadlinesCommand";
+        assert storage != null : "Storage must not be null when executing ListDeadlinesCommand";
+        assert ui != null : "Ui must not be null when executing ListDeadlinesCommand";
         ui.showDeadlineList(moduleBook);
     }
 }

--- a/src/main/java/seedu/modulesync/parser/Parser.java
+++ b/src/main/java/seedu/modulesync/parser/Parser.java
@@ -279,12 +279,17 @@ public class Parser {
      * @throws ModuleSyncException if an unknown filter is provided
      */
     private Command parseList(String input) throws ModuleSyncException {
+        assert input != null && !input.isEmpty() : "Input to parseList must not be null or empty";
         String remainder = extractRemainder(input, CMD_LIST.length());
         if (remainder.isEmpty()) {
-            return new ListCommand();
+            Command cmd = new ListCommand();
+            assert cmd != null : "ListCommand must be created successfully";
+            return cmd;
         }
         if (remainder.toLowerCase().contains(PREFIX_DEADLINES.toLowerCase())) {
-            return new ListDeadlinesCommand();
+            Command cmd = new ListDeadlinesCommand();
+            assert cmd != null : "ListDeadlinesCommand must be created successfully";
+            return cmd;
         }
         throw new ModuleSyncException("Unknown list filter. Try: list /deadlines");
     }

--- a/src/main/java/seedu/modulesync/ui/Ui.java
+++ b/src/main/java/seedu/modulesync/ui/Ui.java
@@ -65,14 +65,20 @@ public class Ui {
      * @param moduleBook the module book containing all modules and tasks
      */
     public void showDeadlineList(ModuleBook moduleBook) {
+        assert moduleBook != null : "ModuleBook must not be null when calling showDeadlineList";
+        
         // Collect all deadlines
         List<DeadlineEntry> deadlines = new ArrayList<>();
         int globalTaskNumber = 1;
         
         for (Module module : moduleBook.getModules()) {
+            assert module != null : "Module retrieved from ModuleBook must not be null";
             for (Task task : module.getTasks().asUnmodifiableList()) {
+                assert task != null : "Task retrieved from TaskList must not be null";
                 if (task instanceof Deadline) {
-                    deadlines.add(new DeadlineEntry((Deadline) task, globalTaskNumber, module.getCode()));
+                    Deadline deadline = (Deadline) task;
+                    assert deadline.getBy() != null : "Deadline date must not be null";
+                    deadlines.add(new DeadlineEntry(deadline, globalTaskNumber, module.getCode()));
                 }
                 globalTaskNumber++;
             }
@@ -85,6 +91,12 @@ public class Ui {
 
         // Sort by deadline (earliest first)
         deadlines.sort((a, b) -> a.deadline.getBy().compareTo(b.deadline.getBy()));
+        
+        // Verify sorting: each deadline should be <= the next deadline
+        for (int i = 0; i < deadlines.size() - 1; i++) {
+            assert deadlines.get(i).deadline.getBy().compareTo(deadlines.get(i + 1).deadline.getBy()) <= 0
+                    : "Deadlines must be sorted in ascending order by due date";
+        }
 
         System.out.println("Here are the upcoming deadlines:");
         for (DeadlineEntry entry : deadlines) {


### PR DESCRIPTION
Implemented a new feature that allows users to list only upcoming deadlines using the `list /deadlines` command. The changes add a specialized command and UI method to display all deadlines in chronological order, helping users plan their week more effectively. The implementation also updates the parser to support filter-based list commands, improving extensibility for future filters. Additionally, the developer guide is updated to ensure proper documentation is accounted for.

close #29 