### PR TITLE
fix: hide delete command stack trace and disable console logging

### DIFF
--- a/duke.log
+++ b/duke.log
@@ -14,3 +14,11 @@
   <message>Application successfully starts</message>
 </record>
 </log>
+Apr 11, 2026 4:29:48 PM seedu.modulesync.command.DeleteCommand execute
+WARNING: Invalid task index: 99
+seedu.modulesync.exception.ModuleSyncException: Task number does not exist: 99
+	at seedu.modulesync.module.ModuleBook.removeTaskByDisplayIndex(ModuleBook.java:108)
+	at seedu.modulesync.command.DeleteCommand.execute(DeleteCommand.java:42)
+	at seedu.modulesync.ModuleSync.run(ModuleSync.java:99)
+	at seedu.modulesync.ModuleSync.main(ModuleSync.java:140)
+

--- a/src/main/java/seedu/modulesync/command/DeleteCommand.java
+++ b/src/main/java/seedu/modulesync/command/DeleteCommand.java
@@ -11,6 +11,18 @@ import seedu.modulesync.ui.Ui;
 
 public class DeleteCommand extends Command {
     private static final Logger logger = Logger.getLogger(DeleteCommand.class.getName());
+
+    static {
+        logger.setUseParentHandlers(false);
+        try {
+            java.util.logging.FileHandler fh = new java.util.logging.FileHandler("duke.log", true);
+            fh.setFormatter(new java.util.logging.SimpleFormatter());
+            logger.addHandler(fh);
+        } catch (Exception e) {
+            // Ignore logger initialization errors
+        }
+    }
+
     private final int displayIndex;
 
     public DeleteCommand(int displayIndex) {


### PR DESCRIPTION
delete with an invalid task index exposes stack trace instead of showing user error. Closes #148
