### PR TITLE
Fix crash when /task flag has empty description

### DIFF
--- a/src/main/java/seedu/modulesync/parser/Parser.java
+++ b/src/main/java/seedu/modulesync/parser/Parser.java
@@ -293,6 +293,13 @@ public class Parser {
         }
 
         int taskContentStart = taskPos + PREFIX_TASK_LENGTH + 1;
+        // Clamp taskContentStart to valid range and ensure it doesn't exceed taskEndPos
+        if (taskContentStart > remainder.length()) {
+            taskContentStart = remainder.length();
+        }
+        if (taskContentStart > taskEndPos) {
+            taskContentStart = taskEndPos;
+        }
         String task = remainder.substring(taskContentStart, taskEndPos).trim();
 
         // Check for duplicate /due flags

--- a/src/test/java/seedu/modulesync/parser/ParserTest.java
+++ b/src/test/java/seedu/modulesync/parser/ParserTest.java
@@ -43,6 +43,9 @@ class ParserTest {
         // /due before /task creates a deadline
         assertTrue(parser.parse("add /mod CS2113 /due 2026-04-15 /task Project") 
             instanceof AddDeadlineCommand);
+        // Empty task description after /task should return module add command
+        assertTrue(parser.parse("add /mod CS2113 /task") instanceof AddModuleCommand);
+        assertTrue(parser.parse("add /mod CS2113 /task    ") instanceof AddModuleCommand);
     }
 
     @Test


### PR DESCRIPTION
- Added bounds checking to prevent StringIndexOutOfBoundsException
- When /task has no description or only whitespace, treat as module add
- Clamp taskContentStart to valid range before substring extraction
- Add test cases for empty task description scenarios