### PR TITLE
Fix delete confirmation message showing 0. index and duplicate module…

### DIFF
--- a/src/main/java/seedu/modulesync/task/Task.java
+++ b/src/main/java/seedu/modulesync/task/Task.java
@@ -156,6 +156,22 @@ public abstract class Task {
     }
 
     /**
+     * Formats this task as a string for display (e.g., in deletion confirmation).
+     * Does not include an index since the task is not in a list position.
+     *
+     * @return the formatted task string: [MODULE] [TYPE][STATUS] description [weightage]
+     */
+    public String formatForDisplay() {
+        String base = "[" + getModuleCode() + "] "
+                + "[" + getTypeCode() + "][" + getStatusIcon() + "] "
+                + description;
+        if (hasWeightage()) {
+            return base + " [" + weightage + "%]";
+        }
+        return base;
+    }
+
+    /**
      * Calculates the priority score for this task.
      *
      * @return the calculated priority score

--- a/src/main/java/seedu/modulesync/ui/Ui.java
+++ b/src/main/java/seedu/modulesync/ui/Ui.java
@@ -511,7 +511,7 @@ public class Ui {
         assert task != null : "Deleted task must not be null";
         assert totalTasks >= 0 : "Total task count must not be negative";
         System.out.println("Noted. I've removed this task:");
-        System.out.println("  [" + task.getModuleCode() + "] " + task.formatForList(0));
+        System.out.println("  " + task.formatForDisplay());
         System.out.println("Now you have " + totalTasks + " task(s) in the list.");
     }
 


### PR DESCRIPTION
- Add formatForDisplay() method to Task for displaying deleted tasks without index
- Update showTaskDeleted() in Ui to use formatForDisplay() instead of duplicating module code
- Fixes issues #130 and #143: delete confirmation now shows 1-based index format consistently with rest of UI and avoids duplicating module code

closes #130 
closes #143 