### PR TITLE
Remove exception logging to prevent stack trace leak in delete command

### DIFF
--- a/src/main/java/seedu/modulesync/command/DeleteCommand.java
+++ b/src/main/java/seedu/modulesync/command/DeleteCommand.java
@@ -1,8 +1,5 @@
 package seedu.modulesync.command;
 
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
 import seedu.modulesync.exception.ModuleSyncException;
 import seedu.modulesync.module.ModuleBook;
 import seedu.modulesync.storage.Storage;
@@ -10,18 +7,6 @@ import seedu.modulesync.task.Task;
 import seedu.modulesync.ui.Ui;
 
 public class DeleteCommand extends Command {
-    private static final Logger logger = Logger.getLogger(DeleteCommand.class.getName());
-
-    static {
-        logger.setUseParentHandlers(false);
-        try {
-            java.util.logging.FileHandler fh = new java.util.logging.FileHandler("duke.log", true);
-            fh.setFormatter(new java.util.logging.SimpleFormatter());
-            logger.addHandler(fh);
-        } catch (Exception e) {
-            // Ignore logger initialization errors
-        }
-    }
 
     private final int displayIndex;
 
@@ -36,23 +21,14 @@ public class DeleteCommand extends Command {
         assert ui != null : "Ui must not be null";
         assert displayIndex > 0 : "Display index must be strictly positive";
 
-        try {
-            int totalBefore = moduleBook.countTotalTasks();
-            assert displayIndex <= totalBefore : "Display index out of bounds";
-            Task deletedTask = moduleBook.removeTaskByDisplayIndex(displayIndex);
-            assert deletedTask != null : "removeTaskByDisplayIndex should return a task when deletion succeeds";
+        int totalBefore = moduleBook.countTotalTasks();
+        Task deletedTask = moduleBook.removeTaskByDisplayIndex(displayIndex);
+        assert deletedTask != null : "removeTaskByDisplayIndex should return a task when deletion succeeds";
 
-            storage.save(moduleBook);
+        storage.save(moduleBook);
 
-            int totalAfter = moduleBook.countTotalTasks();
-            assert totalAfter == totalBefore - 1 : "Total task count should decrease by exactly 1 after deletion";
-            ui.showTaskDeleted(deletedTask, totalAfter);
-        } catch (ModuleSyncException e) {
-            logger.log(Level.WARNING, "Invalid task index: " + displayIndex, e);
-            throw e;
-        } catch (Exception e) {
-            logger.log(Level.WARNING, "Exception caught during task deletion", e);
-            throw new ModuleSyncException("Error during deletion: " + e.getMessage());
-        }
+        int totalAfter = moduleBook.countTotalTasks();
+        assert totalAfter == totalBefore - 1 : "Total task count should decrease by exactly 1 after deletion";
+        ui.showTaskDeleted(deletedTask, totalAfter);
     }
 }

--- a/src/test/java/seedu/modulesync/command/DeleteCommandTest.java
+++ b/src/test/java/seedu/modulesync/command/DeleteCommandTest.java
@@ -53,6 +53,6 @@ public class DeleteCommandTest {
     @Test
     void execute_invalidIndex_throwsException() {
         DeleteCommand command = new DeleteCommand(5);
-        assertThrows(AssertionError.class, () -> command.execute(moduleBook, stubStorage, stubUi));
+        assertThrows(ModuleSyncException.class, () -> command.execute(moduleBook, stubStorage, stubUi));
     }
 }


### PR DESCRIPTION
- Remove try-catch exception handling that logged stack trace with logger.log()
- Remove unused Logger imports and initialization code
- Remove bounds assertion that prevented proper exception handling
- Let ModuleBook.removeTaskByDisplayIndex() throw ModuleSyncException directly
- Update test to expect ModuleSyncException instead of AssertionError
- Fixes issues #112 and #124: delete with invalid index now shows clean error message consistent with mark/unmark commands, not exposing internal stack trace

closes #112 
closes #124 