### PR TITLE
feat: warn user when overwriting existing module grade

### DIFF
--- a/src/main/java/seedu/modulesync/command/GradeCommand.java
+++ b/src/main/java/seedu/modulesync/command/GradeCommand.java
@@ -48,6 +48,13 @@ public class GradeCommand extends Command {
             throw new ModuleSyncException("Module " + moduleCode + " not found.");
         }
 
+        // Warn if overwriting an existing grade
+        if (module.hasGrade()) {
+            String oldGrade = module.getGrade();
+            ui.showMessage("Warning: Module " + moduleCode + " already has grade " 
+                           + oldGrade + ". Overwriting with grade " + grade);
+        }
+
         module.setGrade(grade);
         storage.save(moduleBook);
         ui.showMessage("Grade recorded for module " + moduleCode + ": " + grade);


### PR DESCRIPTION
- Display warning message showing old grade when user grades a module that already has a grade
- User is informed about the overwrite before it happens, not silently replaced
- Fixes #145

closes #145 