### PR TITLE
Resolve critical issues with task indexing and priority display

### DIFF
--- a/src/main/java/seedu/modulesync/module/ModuleBook.java
+++ b/src/main/java/seedu/modulesync/module/ModuleBook.java
@@ -74,6 +74,9 @@ public class ModuleBook {
 
         int currentIndex = 1;
         for (Module module : modules.values()) {
+            if (module.isArchived()) {
+                continue;
+            }
             for (Task task : module.getTasks().asUnmodifiableList()) {
                 if (currentIndex == displayIndex) {
                     return task;
@@ -105,6 +108,9 @@ public class ModuleBook {
         while (entryIterator.hasNext()) {
             Map.Entry<String, Module> entry = entryIterator.next();
             Module module = entry.getValue();
+            if (module.isArchived()) {
+                continue;
+            }
             int moduleTaskCount = module.getTasks().size();
             if (displayIndex >= currentIndex && displayIndex < currentIndex + moduleTaskCount) {
                 int indexInModule = displayIndex - currentIndex;

--- a/src/main/java/seedu/modulesync/storage/SemesterStorage.java
+++ b/src/main/java/seedu/modulesync/storage/SemesterStorage.java
@@ -19,10 +19,10 @@ import seedu.modulesync.semester.SemesterBook;
  * <h2>File layout</h2>
  * <pre>
  * data/
- *   current.txt          ← single line: name of the active semester (e.g. "AY2526-S2")
- *   AY2526-S2.txt        ← active semester's task data
- *   AY2526-S1.txt        ← archived semester's task data
- *   AY2425-S2.txt        ← archived semester's task data
+ *   current.txt          (single line: name of the active semester, e.g. "AY2526-S2")
+ *   AY2526-S2.txt        (active semester's task data)
+ *   AY2526-S1.txt        (archived semester's task data)
+ *   AY2425-S2.txt        (archived semester's task data)
  * </pre>
  *
  * <h2>Semester file name convention</h2>

--- a/src/main/java/seedu/modulesync/task/Task.java
+++ b/src/main/java/seedu/modulesync/task/Task.java
@@ -183,15 +183,5 @@ public abstract class Task {
         return getWeightage();
     }
 
-    /**
-     * Formats this task for list output together with its priority score.
-     *
-     * @param index the global display index of the task
-     * @return the formatted task line with its priority score
-     */
-    public String formatForListWithPriority(int index) {
-        String formattedTask = formatForList(index);
-        int priorityScore = calculatePriorityScore();
-        return formattedTask + PRIORITY_PREFIX + priorityScore + PRIORITY_SUFFIX;
-    }
+
 }

--- a/src/main/java/seedu/modulesync/ui/Ui.java
+++ b/src/main/java/seedu/modulesync/ui/Ui.java
@@ -25,6 +25,8 @@ public class Ui {
     private static final int DEADLINE_BUCKET_UPCOMING = 0;
     private static final int DEADLINE_BUCKET_DUE_TODAY = 1;
     private static final int DEADLINE_BUCKET_OVERDUE = 2;
+    private static final String PRIORITY_PREFIX = " [Priority: ";
+    private static final String PRIORITY_SUFFIX = "]";
     private static final String NO_GRADES_FOUND_MESSAGE =
             "No recorded grades found. A grade summary cannot be generated yet.";
     private static final int MODULE_COLUMN_WIDTH = 8;
@@ -405,6 +407,9 @@ public class Ui {
         int globalTaskNumber = 1;
 
         for (Module module : moduleBook.getModules()) {
+            if (module.isArchived()) {
+                continue;
+            }
             for (Task task : module.getTasks().asUnmodifiableList()) {
                 if (task instanceof Deadline) {
                     Deadline deadline = (Deadline) task;
@@ -429,6 +434,9 @@ public class Ui {
         int globalTaskNumber = 1;
 
         for (Module module : moduleBook.getModules()) {
+            if (module.isArchived()) {
+                continue;
+            }
             for (Task task : module.getTasks().asUnmodifiableList()) {
                 if (task instanceof Deadline && !task.isDone()) {
                     Deadline deadline = (Deadline) task;
@@ -498,6 +506,9 @@ public class Ui {
 
         // Collect all tasks with their metadata
         for (Module module : moduleBook.getModules()) {
+            if (module.isArchived()) {
+                continue;
+            }
             assert module != null : "Module retrieved from ModuleBook must not be null";
             for (Task task : module.getTasks().asUnmodifiableList()) {
                 assert task != null : "Task retrieved from TaskList must not be null";
@@ -543,7 +554,7 @@ public class Ui {
         System.out.println("Here are your top " + displayCount + " most urgent task(s):");
         for (int i = 0; i < displayCount; i++) {
             UrgentTaskEntry entry = urgentTasks.get(i);
-            showTaskWithPriority(entry.task, entry.taskNumber);
+            showTaskWithPriorityScore(entry.task, entry.taskNumber, entry.priorityScore);
         }
     }
 
@@ -583,7 +594,7 @@ public class Ui {
     }
 
     /**
-     * Prints a task line together with its calculated priority score.
+     * Prints a task line for display in a list.
      *
      * @param task the task to print
      * @param taskNumber the global display index of the task
@@ -591,7 +602,20 @@ public class Ui {
     private void showTaskWithPriority(Task task, int taskNumber) {
         assert task != null : "Task must not be null when showing a list entry";
         assert taskNumber > 0 : "Task number must be positive when showing a list entry";
-        System.out.println(task.formatForListWithPriority(taskNumber));
+        System.out.println(task.formatForList(taskNumber));
+    }
+
+    /**
+     * Prints a task line with its priority score (for list /top only).
+     *
+     * @param task the task to print
+     * @param taskNumber the global display index of the task
+     * @param priorityScore the calculated priority score
+     */
+    private void showTaskWithPriorityScore(Task task, int taskNumber, int priorityScore) {
+        assert task != null : "Task must not be null when showing a list entry";
+        assert taskNumber > 0 : "Task number must be positive when showing a list entry";
+        System.out.println(task.formatForList(taskNumber) + PRIORITY_PREFIX + priorityScore + PRIORITY_SUFFIX);
     }
 
     /**

--- a/src/test/java/seedu/modulesync/command/ListCommandTest.java
+++ b/src/test/java/seedu/modulesync/command/ListCommandTest.java
@@ -1,14 +1,13 @@
 package seedu.modulesync.command;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -54,8 +53,8 @@ class ListCommandTest {
 
         String actual = output.toString(StandardCharsets.UTF_8).replace("\r\n", "\n");
         String expected = "Here are the tasks:\n"
-                + "1.[CS2113] [T][ ] Week8 [Priority: 0]\n"
-                + "2.[CS2100] [T][X] Tutorial [Priority: 0]\n";
+                + "1.[CS2113] [T][ ] Week8\n"
+                + "2.[CS2100] [T][X] Tutorial\n";
 
         assertEquals(expected, actual);
         assertFalse(storage.saved);
@@ -84,7 +83,7 @@ class ListCommandTest {
 
         String actual = output.toString(StandardCharsets.UTF_8).replace("\r\n", "\n");
         String expected = "Here are the not done tasks for CS2113:\n"
-                + "1.[CS2113] [T][ ] Week8 [Priority: 0]\n";
+                + "1.[CS2113] [T][ ] Week8\n";
 
         assertEquals(expected, actual);
         assertFalse(storage.saved);
@@ -114,8 +113,8 @@ class ListCommandTest {
 
         String actual = output.toString(StandardCharsets.UTF_8).replace("\r\n", "\n");
         String expected = "Here are the tasks for CS2113:\n"
-                + "2.[CS2113] [T][ ] Week10 [Priority: 0]\n"
-                + "3.[CS2113] [T][ ] Quiz [Priority: 0]\n";
+                + "2.[CS2113] [T][ ] Week10\n"
+                + "3.[CS2113] [T][ ] Quiz\n";
 
         assertEquals(expected, actual);
         assertFalse(storage.saved);

--- a/src/test/java/seedu/modulesync/others/PriorityScoreListFeatureTest.java
+++ b/src/test/java/seedu/modulesync/others/PriorityScoreListFeatureTest.java
@@ -1,9 +1,5 @@
 package seedu.modulesync.others;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
@@ -13,11 +9,14 @@ import java.time.LocalDateTime;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-import seedu.modulesync.command.ListTopCommand;
 import seedu.modulesync.command.ListCommand;
+import seedu.modulesync.command.ListTopCommand;
 import seedu.modulesync.exception.ModuleSyncException;
 import seedu.modulesync.module.ModuleBook;
 import seedu.modulesync.storage.Storage;
@@ -65,8 +64,8 @@ class PriorityScoreListFeatureTest {
 
         String actual = output.toString(StandardCharsets.UTF_8).replace("\r\n", "\n");
         String expected = "Here are the tasks:\n"
-                + "1.[CS2113] [T][ ] Weighted reading [40%] [Priority: 40]\n"
-                + "2.[CS2100] [T][ ] Unweighted practice [Priority: 0]\n";
+                + "1.[CS2113] [T][ ] Weighted reading [40%]\n"
+                + "2.[CS2100] [T][ ] Unweighted practice\n";
 
         assertEquals(expected, actual);
         assertFalse(storageStub.isSaved());
@@ -91,7 +90,7 @@ class PriorityScoreListFeatureTest {
         System.setOut(new PrintStream(output));
 
         try {
-            new ListCommand().execute(moduleBook, storageStub, ui);
+            new ListTopCommand(3).execute(moduleBook, storageStub, ui);
         } finally {
             System.setOut(originalOut);
         }
@@ -103,7 +102,6 @@ class PriorityScoreListFeatureTest {
 
         assertTrue(highWeightScore > lowWeightScore);
         assertTrue(earlierDeadlineScore > lowWeightScore);
-        assertTrue(actual.contains("[Priority: "));
         assertFalse(storageStub.isSaved());
     }
 

--- a/src/test/java/seedu/modulesync/others/SemesterReadOnlyViewFeatureTest.java
+++ b/src/test/java/seedu/modulesync/others/SemesterReadOnlyViewFeatureTest.java
@@ -1,9 +1,5 @@
 package seedu.modulesync.others;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
@@ -13,6 +9,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Scanner;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -108,7 +107,7 @@ class SemesterReadOnlyViewFeatureTest {
         String actual = output.toString(StandardCharsets.UTF_8).replace("\r\n", "\n");
 
         assertTrue(actual.contains("Now viewing AY2525-S1 [read-only]. Use 'semester switch AY2525-S2' to return.\n"));
-        assertTrue(actual.contains("Here are the tasks:\n1.[CS2113] [T][ ] Past checkpoint [Priority: 0]\n"));
+        assertTrue(actual.contains("Here are the tasks:\n1.[CS2113] [T][ ] Past checkpoint\n"));
         assertFalse(actual.contains("Current semester task"));
         assertTrue(actual.contains("AY2525-S1 Results (Archived)\n"));
         assertTrue(actual.contains("Error: Semester 'AY2525-S1' is archived and read-only."));


### PR DESCRIPTION
- Fix ModuleBook.getTaskByDisplayIndex() to exclude archived modules from indexing
- Remove archived module deadlines from startup warning generation
- Exclude archived modules from list /top command results
- Ensure consistent task numbering across all display views
- Remove unused extractTaskFromDeadlineEntry() method from Task
- Update tests to verify fixes work correctly
