### PR TITLE
Add Project Portfolio Pages links to docs README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,3 +6,10 @@ Useful links:
 * [User Guide](UserGuide.md)
 * [Developer Guide](DeveloperGuide.md)
 * [About Us](AboutUs.md)
+
+## Project Portfolio Pages
+* [codefuul](team/codefuul.md)
+* [heeelol](team/heeelol.md)
+* [huang-hau-shuan](team/huang-hau-shuan.md)
+* [johndoe](team/johndoe.md)
+* [Notchennie1](team/Notchennie1.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,5 +11,5 @@ Useful links:
 * [codefuul](team/codefuul.md)
 * [heeelol](team/heeelol.md)
 * [huang-hau-shuan](team/huang-hau-shuan.md)
-* [johndoe](team/johndoe.md)
+* [fromtyn](team/fromtyn.md)
 * [Notchennie1](team/Notchennie1.md)


### PR DESCRIPTION
- Add new 'Project Portfolio Pages' section
- Include links to all team members' PPPs
- Enable viewing PPPs as HTML on GitHub Pages site